### PR TITLE
feat: :rocket: bump 0.0.1-rc.2 and support browser

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -21,17 +21,48 @@ $ yarn add @vn-utils/text
 ### PNPM
 
 ```bash
-$ pnpm add @vn-utils/text
+$ pnpm install @vn-utils/text
+```
+
+### Browser
+
+```html
+<!-- Latest -->
+<script src="https://unpkg.com/@vn-utils/text/lib/bundle.js"></script>
+
+<!-- Or with selected version -->
+<script src="https://unpkg.com/@vn-utils/text@<VERSION_HERE>/lib/bundle.js"></script>
 ```
 
 ## Sử dụng thư viện
 
 ### Import thư viện
 
+#### Node
+
 ```typescript
 // ES Module
-import * as vietnameseText from '@vn-utils/text';
+import * as vnUtilsText from '@vn-utils/text';
 
 // CommonJS
-const vietnameseText = require('@vn-utils/text');
+const vnUtilsText = require('@vn-utils/text');
+```
+
+#### Browser
+
+-   Sử dụng biến `vnUtilsText` để sử dụng thư viện
+
+```html
+<script>
+    vnUtilsText.hasTone('các dấu sắc huyền ngã hỏi nặng có tồn tại');
+</script>
+```
+
+-   Hoặc gán bằng biến mới:
+
+```html
+<script>
+    const customVariable = vnUtilsText;
+    customVariable.hasTone('các dấu sắc huyền ngã hỏi nặng có tồn tại');
+</script>
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@vn-utils/text",
-    "version": "0.0.1-rc.1",
+    "version": "0.0.1-rc.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@vn-utils/text",
-            "version": "0.0.1-rc.1",
+            "version": "0.0.1-rc.2",
             "license": "MIT",
             "devDependencies": {
                 "@babel/cli": "^7.24.5",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "type": "git",
         "url": "git+https://github.com/lehuygiang28/text.git"
     },
-    "version": "0.0.1-rc.1",
+    "version": "0.0.1-rc.2",
     "description": "Utilities for work with Vietnamese text",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",
@@ -12,9 +12,9 @@
         "lib"
     ],
     "scripts": {
-        "build": "rimraf ./lib && tsc & webpack",
-        "lib": "rimraf ./lib && tsc",
-        "bundle": "rimraf ./lib && webpack",
+        "build": "rimraf ./lib && webpack && tsc && rimraf ./lib/export.bundle.d.ts",
+        "lib": "rimraf ./lib && tsc && rimraf ./lib/export.bundle.d.ts",
+        "bundle": "rimraf ./lib && webpack && rimraf ./lib/**/*.d.ts --glob",
         "prepare": "npm run build",
         "test": "jest",
         "test:cov": "jest --coverage",
@@ -25,11 +25,13 @@
         "prettier:fix": "prettier --write ."
     },
     "keywords": [
+        "vietnamese text",
+        "vietnamese text search",
         "tone mark",
         "vietnamese",
         "search vietnamese",
         "tone mark vietnamese",
-        "vietnamese text search"
+        "diacritics vietnamese"
     ],
     "author": "lehuygiang28 <lehuygiang28@gmail.com>",
     "license": "MIT",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation instructions for `@vn-utils/text` to use `pnpm` instead of `yarn`.
  - Revised import statements and usage examples for Node and Browser environments.

- **Chores**
  - Incremented version to `0.0.1-rc.2`.
  - Enhanced build scripts for better cleanup and processing.
  - Expanded keywords in `package.json` to improve discoverability related to Vietnamese text processing utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->